### PR TITLE
Pay 2033

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,10 @@ Common.load = next => {
             'city', 'state', 'province', 'zip', 'phone', 'birth_month', 'birth_day', 'birth_year',
             'signature', 'accountNumber', 'routingNumber', 'ssn']
         };
-        bugsnag.register(Config.get('BUGSNAG_LAMBDAS_KEY'), options);
         for (let x of process.listeners('uncaughtException')) {
           process.removeListener('uncaughtException', x);
         }
+        bugsnag.register(Config.get('BUGSNAG_LAMBDAS_KEY'), options);
         process.on('uncaughtException', (err) => {
           bugsnag.notify(err);
         });

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ Common.load = next => {
             'signature', 'accountNumber', 'routingNumber', 'ssn']
         };
         bugsnag.register(Config.get('BUGSNAG_LAMBDAS_KEY'), options);
+        for (let x of process.listeners('uncaughtException')) {
+          process.removeListener('uncaughtException', x);
+        }
         process.on('uncaughtException', (err) => {
           bugsnag.notify(err);
         });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "bugsnag": "^1.12.2",
     "bunyan": "^1.8.12",
-    "bunyan-loggly": "^1.2.0",
+    "bunyan-loggly": "1.2.0",
     "classy-api-client": "^1.0.0",
     "classy-pay-client": "^1.0.0",
     "config-lambda": "^1.0.3",


### PR DESCRIPTION
bunyan-loggly update caused a hangin issue in the lambda functions. Hardcoding to specific version to stop timeouts.

Also remove lamda's default uncaught exception handler so that we may catch errors