### PR TITLE
Fixup a few bugs with Common.async(), proxify objects returned by asy…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,20 +51,27 @@ module.exports = {
   },
 
   async: function() {
-    return {
-      get: async () => {
+    return new Proxy({
+      get: async (key) => {
         await this.initialize();
         const value = _.get(this, key, null);
         if (value) {
           return value;
         }
-        return await Config.get(key);
+        return await this.config.get(key);
       }
-    };
+    }, {
+      get: function(obj, prop) {
+        if (prop in obj) {
+          return obj[prop];
+        }
+        return obj.get(prop);
+      }
+    });
   },
 
   legacy: function() {
-    return {
+    return new Proxy({
       load: next => {
         this.initialize().then(() => {
           _.defer(next);
@@ -83,7 +90,14 @@ module.exports = {
         }
         return this.config.legacy().get(key);
       }
-    };
+    }, {
+      get: function(obj, prop) {
+        if (prop in obj) {
+          return obj[prop];
+        }
+        return obj.get(prop);
+      }
+    });
   },
 
   load: function(next) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,14 +1,14 @@
 'use strict';
 require('source-map-support').install();
-const Common = require('../lib/index.js');
+const Common = require('../lib/index.js').legacy();
 let log;
 Common.load(function(error) {
   if (error) {
     console.log(error);
   } else {
-    log = Common.get('Logger').create('test');
+    log = Common.Logger.create('test');
     log.info('Testing 1 2 3');
-    log.info(Common.get('LOG_LOGGLY_TOKEN'));
-    log.info(Common.get('log.logger'));
+    log.info(Common.LOG_LOGGLY_TOKEN);
+    log.info(Common.log.logger);
   }
 });

--- a/test/testAsync.js
+++ b/test/testAsync.js
@@ -1,0 +1,17 @@
+'use strict';
+require('source-map-support').install();
+require('regenerator-runtime/runtime');
+const Common = require('../lib/index.js').async();
+
+const f = async () => {
+  try {
+    let log = (await Common.Logger).create('test');
+    log.info('Testing 1 2 3');
+    log.info(await Common.LOG_LOGGLY_TOKEN);
+    log.info(await Common.log.logger);
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+f();


### PR DESCRIPTION
…nc() and legacy() so you can use them like normal dictionaries